### PR TITLE
fixed repeated import bug

### DIFF
--- a/frontend/src/components/Buttons/Buttons.js
+++ b/frontend/src/components/Buttons/Buttons.js
@@ -4,7 +4,6 @@ import React from "react";
 
 // Internal Imports
 import { combineClasses } from "../Utility/utils";
-import "./_Buttons.scss";
 
 // Default button size/colour/variant is small/primary/base
 function Button({

--- a/frontend/src/components/Buttons/CloseButton.js
+++ b/frontend/src/components/Buttons/CloseButton.js
@@ -5,7 +5,6 @@ import PropTypes from "prop-types";
 // Internal Imports
 import { combineClasses } from "../Utility/utils";
 import { iconX } from "../../assets/images/images";
-import "./_CloseButton.scss";
 
 function CloseButton(props) {
   return (

--- a/frontend/src/components/Cards/Cards.js
+++ b/frontend/src/components/Cards/Cards.js
@@ -5,7 +5,6 @@ import React, { useState } from "react";
 // Internal Imports
 import { combineClasses } from "../Utility/utils";
 import { CloseButton } from "../Buttons/CloseButton";
-import "./_Cards.scss";
 
 function CopCard({ hidden = true, size = "sm", ...props }) {
   const [isHidden, setIsHidden] = useState(hidden);

--- a/frontend/src/components/Carousel/ClickCarousel.js
+++ b/frontend/src/components/Carousel/ClickCarousel.js
@@ -5,7 +5,6 @@ import React, { Fragment, useEffect, useRef, useState } from "react";
 // Internal Imports
 import { combineClasses } from "../Utility/utils";
 import { Button } from "../Buttons/Buttons";
-import "./_Carousel.scss";
 
 function ClickCarousel({ hidden = false, selected = 0, ...props }) {
   const [items, setItems] = useState([]);

--- a/frontend/src/components/Carousel/ScrollCarousel.js
+++ b/frontend/src/components/Carousel/ScrollCarousel.js
@@ -4,7 +4,6 @@ import React, { useEffect, useRef, useState } from "react";
 
 // Internal Imports
 import { combineClasses } from "../Utility/utils";
-import "./_ScrollCarousel.scss";
 
 // Note, all the functions in this component mimics the expected behavior of scroll-snap-stop: always. Since this is not supported in FireFox, this needs to be recreated until support is reached.
 function ScrollCarousel({ hidden = false, ...props }) {

--- a/frontend/src/components/Navigation/HeaderNav.js
+++ b/frontend/src/components/Navigation/HeaderNav.js
@@ -5,7 +5,6 @@ import React, { useState } from "react";
 // Internal Imports
 import * as utility from "../Utility/utils";
 import { IconHamburgerMenu } from "../../assets/images/images";
-import "./_HeaderNav.scss";
 import { Button } from "../Buttons/Buttons";
 
 function HeaderNav({ logoDesktop, logoMobile, menu, ...props }) {

--- a/frontend/src/components/Navigation/InnerCopNav.js
+++ b/frontend/src/components/Navigation/InnerCopNav.js
@@ -12,7 +12,6 @@ import {
 } from "../../assets/images/images";
 import { InnerCopNavCard } from "../Cards/Cards";
 import * as utility from "../Utility/utils";
-import "./_InnerCopNav.scss";
 
 function InnerCopNav(props) {
   const [activeIndex, setActiveIndex] = useState(9);

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1,6 +1,11 @@
 @use "components/normalize";
 @use "components/Basics" as *;
 @use "components/Buttons/Buttons" as *;
+@use "components/Buttons/CloseButton";
+@use "components/Cards/Cards";
+@use "components/Carousel/ScrollCarousel";
+@use "components/Navigation/HeaderNav";
+@use "components/Navigation/InnerCopNav";
 
 body {
   font-family: Roboto, Arial, Helvetica, sans-serif;

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1,11 +1,21 @@
+// Normalize all styles
 @use "components/normalize";
+
+// Import basic styles
 @use "components/Basics" as *;
+
+// Import component styles
 @use "components/Buttons/Buttons" as *;
 @use "components/Buttons/CloseButton";
 @use "components/Cards/Cards";
 @use "components/Carousel/ScrollCarousel";
 @use "components/Navigation/HeaderNav";
 @use "components/Navigation/InnerCopNav";
+
+// Import page styles
+
+
+// Create final styles
 
 body {
   font-family: Roboto, Arial, Helvetica, sans-serif;


### PR DESCRIPTION
<!-- Please link an issue via keyword. If you do not know what this means, please click this link: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword. -->

This is a quick fix for an import bug that has been causing class overriding to not work as intended.

<!-- Please note all the changes you've made. A good rule of thumb is to have at least one bullet point per file changed. -->

### Changes

- Moved all imports from individual js files to `index.scss`

<!-- Please ignore everything below until #78 closes. -->

<!-- Please attach full page screenshots of changes to the website's appearance before and after code changes in HTML drop boxes (see below template). DO NOT POST PICTURES OF YOUR CODE! -->

<!-- Commented out
### Screenshots, if applicable

<details>
  <summary>Title</summary>
  <br>
  <img src="" width="600" length="300" />
  <br>
</details>
-->
    
