### PR TITLE
Build accessibility text  into inline svgs

### DIFF
--- a/app/frontend/src/assets/images/images.js
+++ b/app/frontend/src/assets/images/images.js
@@ -20,6 +20,10 @@ import iconDownArrow from "./svgs/icon-down-arrow.svg?url";
 import iconHamburgerMenu from "./svgs/icon-hamburger-menu.svg?url";
 import iconX from "./svgs/icon-x.svg?url";
 
+// Group Background Image
+import landingPageFg from "./svgs/landing-page-fg.svg?url";
+import landingPageBg from "./svgs/landing-page-bg.svg?url";
+
 // CTJ Logos
 import LogoHorizontal from "./svgs/logo-horizontal.svg";
 import LogoHorizontalOnDark from "./svgs/logo-horizontal-on-dark.svg";
@@ -38,10 +42,6 @@ import logoStackedOnDark from "./svgs/logo-stacked-on-dark.svg?url";
 import logoType from "./svgs/logo-logotype.svg?url";
 import logoVertical from "./svgs/logo-vertical.svg?url";
 import logoWordmark from "./svgs/logo-wordmark.svg?url";
-
-// Group Background Image
-import landingPageFg from "./svgs/landing-page-fg.svg?url";
-import landingPageBg from "./svgs/landing-page-bg.svg?url";
 
 export {
   // COP Icons

--- a/app/frontend/src/assets/images/images.js
+++ b/app/frontend/src/assets/images/images.js
@@ -1,3 +1,5 @@
+import React from "react";
+
 // COP Icons
 import CopIconData from "./svgs/cop-icon-datascience.svg";
 import CopIconEngineering from "./svgs/cop-icon-engineering.svg";
@@ -31,7 +33,7 @@ import LogoMark from "./svgs/logo-logomark.svg";
 import LogoStacked from "./svgs/logo-stacked.svg";
 import LogoStackedOnDark from "./svgs/logo-stacked-on-dark.svg";
 import LogoType from "./svgs/logo-logotype.svg";
-import LogoVertical from "./svgs/logo-vertical.svg";
+import LogoVerticalP from "./svgs/logo-vertical.svg";
 import LogoWordmark from "./svgs/logo-wordmark.svg";
 
 import logoHorizontal from "./svgs/logo-horizontal.svg?url";
@@ -42,6 +44,17 @@ import logoStackedOnDark from "./svgs/logo-stacked-on-dark.svg?url";
 import logoType from "./svgs/logo-logotype.svg?url";
 import logoVertical from "./svgs/logo-vertical.svg?url";
 import logoWordmark from "./svgs/logo-wordmark.svg?url";
+
+function svgWrapper(Svg, defaultProps) {
+  return (props) => {
+    return <Svg {...defaultProps} {...props}></Svg>;
+  };
+}
+
+const LogoVertical = svgWrapper(LogoVerticalP, {
+  title: "Civic Tech Jobs Logo",
+  titleId: "ctj-logo-vertical",
+});
 
 export {
   // COP Icons

--- a/app/frontend/src/assets/images/images.js
+++ b/app/frontend/src/assets/images/images.js
@@ -1,11 +1,11 @@
 import React from "react";
 
 // COP Icons
-import CopIconData from "./svgs/cop-icon-datascience.svg";
-import CopIconEngineering from "./svgs/cop-icon-engineering.svg";
-import CopIconOps from "./svgs/cop-icon-ops.svg";
-import CopIconProduct from "./svgs/cop-icon-product.svg";
-import CopIconUiux from "./svgs/cop-icon-uiux.svg";
+import CopIconDataP from "./svgs/cop-icon-datascience.svg";
+import CopIconEngineeringP from "./svgs/cop-icon-engineering.svg";
+import CopIconOpsP from "./svgs/cop-icon-ops.svg";
+import CopIconProductP from "./svgs/cop-icon-product.svg";
+import CopIconUiuxP from "./svgs/cop-icon-uiux.svg";
 
 import copIconData from "./svgs/cop-icon-datascience.svg?url";
 import copIconEngineering from "./svgs/cop-icon-engineering.svg?url";
@@ -27,14 +27,14 @@ import landingPageFg from "./svgs/landing-page-fg.svg?url";
 import landingPageBg from "./svgs/landing-page-bg.svg?url";
 
 // CTJ Logos
-import LogoHorizontal from "./svgs/logo-horizontal.svg";
-import LogoHorizontalOnDark from "./svgs/logo-horizontal-on-dark.svg";
-import LogoMark from "./svgs/logo-logomark.svg";
-import LogoStacked from "./svgs/logo-stacked.svg";
-import LogoStackedOnDark from "./svgs/logo-stacked-on-dark.svg";
-import LogoType from "./svgs/logo-logotype.svg";
+import LogoHorizontalP from "./svgs/logo-horizontal.svg";
+import LogoHorizontalOnDarkP from "./svgs/logo-horizontal-on-dark.svg";
+import LogoMarkP from "./svgs/logo-logomark.svg";
+import LogoStackedP from "./svgs/logo-stacked.svg";
+import LogoStackedOnDarkP from "./svgs/logo-stacked-on-dark.svg";
+import LogoTypeP from "./svgs/logo-logotype.svg";
 import LogoVerticalP from "./svgs/logo-vertical.svg";
-import LogoWordmark from "./svgs/logo-wordmark.svg";
+import LogoWordmarkP from "./svgs/logo-wordmark.svg";
 
 import logoHorizontal from "./svgs/logo-horizontal.svg?url";
 import logoHorizontalOnDark from "./svgs/logo-horizontal-on-dark.svg?url";
@@ -45,15 +45,85 @@ import logoType from "./svgs/logo-logotype.svg?url";
 import logoVertical from "./svgs/logo-vertical.svg?url";
 import logoWordmark from "./svgs/logo-wordmark.svg?url";
 
+/**
+ * A wrapper that pre-adds certain attributes to svgs that does not need to be customized
+ * @param {*} Svg an svg component as rendered by svgr
+ * @param {*} defaultProps an object containing the attributes to add
+ * @returns a wrapped component
+ */
 function svgWrapper(Svg, defaultProps) {
   return (props) => {
     return <Svg {...defaultProps} {...props}></Svg>;
   };
 }
 
+// COP Icons
+const CopIconData = svgWrapper(CopIconDataP, {
+  title: "Data Science Community of Practice Logo",
+  titleId: "data-cop-logo",
+});
+
+const CopIconEngineering = svgWrapper(CopIconEngineeringP, {
+  title: "Engineering Community of Practice Logo",
+  titleId: "eng-cop-logo",
+});
+
+const CopIconOps = svgWrapper(CopIconOpsP, {
+  title: "Ops Community of Practice Logo",
+  titleId: "ops-cop-logo",
+});
+
+const CopIconProduct = svgWrapper(CopIconProductP, {
+  title: "Product Management Community of Practice Logo",
+  titleId: "prod-cop-logo",
+});
+
+const CopIconUiux = svgWrapper(CopIconUiuxP, {
+  title: "UI/UX Community of Practice Logo",
+  titleId: "uiux-cop-logo",
+});
+
+// CTJ Logos
+const ctjLogoTitle = "Civic Tech Jobs Logo";
+
+const LogoHorizontal = svgWrapper(LogoHorizontalP, {
+  title: ctjLogoTitle,
+  titleId: "ctj-logo-horizontal",
+});
+
+const LogoHorizontalOnDark = svgWrapper(LogoHorizontalOnDarkP, {
+  title: ctjLogoTitle,
+  titleId: "ctj-logo-horizontal-dark",
+});
+
+const LogoMark = svgWrapper(LogoMarkP, {
+  title: ctjLogoTitle,
+  titleId: "ctj-logo-mark",
+});
+
+const LogoStacked = svgWrapper(LogoStackedP, {
+  title: ctjLogoTitle,
+  titleId: "ctj-logo-stacked",
+});
+
+const LogoStackedOnDark = svgWrapper(LogoStackedOnDarkP, {
+  title: ctjLogoTitle,
+  titleId: "ctj-logo-stacked-dark",
+});
+
+const LogoType = svgWrapper(LogoTypeP, {
+  title: ctjLogoTitle,
+  titleId: "ctj-logo-type",
+});
+
 const LogoVertical = svgWrapper(LogoVerticalP, {
-  title: "Civic Tech Jobs Logo",
+  title: ctjLogoTitle,
   titleId: "ctj-logo-vertical",
+});
+
+const LogoWordmark = svgWrapper(LogoWordmarkP, {
+  title: ctjLogoTitle,
+  titleId: "ctj-logo-workmark",
 });
 
 export {

--- a/app/frontend/src/pages/Demo/Demo.js
+++ b/app/frontend/src/pages/Demo/Demo.js
@@ -1,5 +1,6 @@
 // External Imports
 import React from "react";
+import { LogoVertical } from "assets/images/images";
 
 function Demo() {
   return (
@@ -7,6 +8,7 @@ function Demo() {
       <h1>
         Hello World! Feel free to use this page as a playground to test code!
       </h1>
+      <LogoVertical />
     </div>
   );
 }

--- a/app/frontend/src/pages/LandingPage/LandingPageCop.js
+++ b/app/frontend/src/pages/LandingPage/LandingPageCop.js
@@ -52,7 +52,7 @@ function LandingPageCop() {
             >
               <div style={{ display: "flex", flexDirection: "column" }}>
                 <div className="pb-3 row justify-center">
-                  <cop.icon strokeWidth="0.2" height="65" />
+                  <cop.icon strokeWidth="0.2" height="65" aria-hidden="true" />
                 </div>
                 <div className="title-4 landing-cop-circle-title text-center">
                   {cop.title}
@@ -93,6 +93,7 @@ function LandingPageCop() {
                         strokeWidth="0.2"
                         height="24"
                         width="24"
+                        aria-hidden="true"
                       />
                     </div>
                     <span className="title-6 landing-cop-nav-title">
@@ -114,6 +115,7 @@ function LandingPageCop() {
                           strokeWidth="0.2"
                           height="50"
                           width="50"
+                          aria-hidden="true"
                         />
                       )}
                     </div>

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -48,7 +48,16 @@ module.exports = {
           },
           {
             issuer: /\.[jt]sx?$/,
-            use: ["@svgr/webpack"],
+            resourceQuery: { not: [/url/] }, // exclude react component if *.svg?url
+            use: [
+              {
+                loader: "@svgr/webpack",
+                options: {
+                  titleProp: true,
+                  svgoConfig: { removeTitle: false, removeDesc: false },
+                },
+              },
+            ],
           },
         ],
       },

--- a/mkdocs/docs/developer/design-system.md
+++ b/mkdocs/docs/developer/design-system.md
@@ -229,7 +229,7 @@ _<p style="text-align: center;">DON'T: declare `*-responsive` mixins without a d
 
 ### SVGs as Components and as Data-URLs
 
-SVG assets are read into our codebase as React components or data-urls.
+SVG assets are read into our codebase as React components (or inline SVG) or data-urls.
 
 As React components:
 
@@ -264,7 +264,7 @@ import copIconProduct from "./svgs/cop-icon-product.svg?url";
 import copIconUiux from "./svgs/cop-icon-uiux.svg?url";
 ```
 
-_<p style="text-align: center;">The top icons are imported from the image file as SVG components. The bottom icons are the same file imported as data-urls. Notice how the latter import file adds "?url".</p>_
+_<p style="text-align: center;">The top icons are imported from the image file as SVG components (or inline SVG). The bottom icons are the same file imported as data-urls. Notice how the latter import file adds "?url".</p>_
 
 When using our SVG assets make sure to use the best import for the job. In some cases, however, neither of these imports are optimal to use. For example the SVG itself might be incorrectly formatted.
 


### PR DESCRIPTION
<!-- Please link an issue via keyword. If you do not know what this means, please click this link: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword. -->

Fixes #230

<!-- Please note all the changes you've made. A good rule of thumb is to have at least one bullet point per file changed. -->

### Changes

- Added svgWrapper function inside of `image.js` redirection file to add accessibility text to SVG components
- Edited import wording slightly so enable effective wrapping without breaking existing code. Wrapped import names are now appended with P (for pre-wrapped) at the end
- Configured webpack to allow for accessibility props
- Edited currently used svgs for accessibility
- Small changes to docs

<!-- Please ignore everything below until #78 closes. -->

<!-- Please attach full page screenshots of changes to the website's appearance before and after code changes in HTML drop boxes (see below template). DO NOT POST PICTURES OF YOUR CODE! -->

<!-- Commented out
### Screenshots, if applicable

<details>
  <summary>Title</summary>
  <br>
  <img src="" width="600" length="300" />
  <br>
</details>
-->
    
