### PR TITLE
Update configure-aws-credentials to v2

### DIFF
--- a/.github/workflows/build-deploy-stage.yml
+++ b/.github/workflows/build-deploy-stage.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build-deploy-stage.yml
+++ b/.github/workflows/build-deploy-stage.yml
@@ -61,7 +61,7 @@ jobs:
           cd app
           docker build -f ../stage/Dockerfile -t "$ECR_REGISTRY"/"$ECR_REPOSITORY":"$IMAGE_TAG" .
           docker push "$ECR_REGISTRY"/"$ECR_REPOSITORY":"$IMAGE_TAG"
-          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Fill in templated fields of ECS task definition
         id: task-def-update


### PR DESCRIPTION
<!-- Please link an issue via keyword. If you do not know what this means, please click this link: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword. -->

Fixes #379

<!-- Please note all the changes you've made. A good rule of thumb is to have at least one bullet point per file changed. -->

### Changes

- Updated `aws-actions/configure-aws-credentials` from `v1` to `v2`


### Why

- Both the node version and `set-output` warning occur during the `Configure AWS credentials` step that uses `configure-aws-credentials@v1`


### Concerns
- I'm not sure how to find a migration guide but the [recent updates section](https://github.com/aws-actions/configure-aws-credentials#recent-updates) of `configure-aws-credentials` README explains 

> We've recently released a v2 of this action that uses the Node 16 runtime by default. You should update your action references to v2... When migrating to v2, you don't have to consider any changes other than the node version. There are no breaking changes between versions; As of release of v2, the node version is the only change.


<!-- Please ignore everything below until #78 closes. -->

<!-- Please attach full page screenshots of changes to the website's appearance before and after code changes in HTML drop boxes (see below template). DO NOT POST PICTURES OF YOUR CODE! -->

<!-- Commented out
### Screenshots, if applicable

<details>
  <summary>Title</summary>
  <br>
  <img src="" width="600" length="300" />
  <br>
</details>
-->
