### PR TITLE
Add pre-commit hook for prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,7 @@ repos:
             "--rcfile=app/setup.cfg",
           ]
         additional_dependencies: [django, djangorestframework, pylint_django]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v2.7.1"
+    hooks:
+      - id: prettier

--- a/dev/linter.dockerfile
+++ b/dev/linter.dockerfile
@@ -13,8 +13,8 @@ RUN apk add --no-cache \
   python3-dev~=3.9 \
   musl-dev~=1.2 \
   py3-pip~=20.3 \
-  nodejs \
-  npm
+  nodejs~=16.20 \
+  npm~=8.1.3
 
 
 # install python dependencies

--- a/dev/linter.dockerfile
+++ b/dev/linter.dockerfile
@@ -12,7 +12,9 @@ RUN apk add --no-cache \
   python3~=3.9 \
   python3-dev~=3.9 \
   musl-dev~=1.2 \
-  py3-pip~=20.3
+  py3-pip~=20.3 \
+  nodejs \
+  npm
 
 
 # install python dependencies
@@ -21,9 +23,10 @@ ENV PYTHONUNBUFFERED=1
 RUN ln -sf python3 /usr/bin/python &&\
   python -m ensurepip &&\
   pip3 install --no-cache --no-cache-dir --ignore-installed --upgrade \
-    pip==22.1 \
-    pre-commit==2.19 \
-    setuptools==62.3
+  pip==22.1 \
+  pre-commit==2.19 \
+  setuptools==62.3
+
 
 WORKDIR /src
 ENTRYPOINT ["pre-commit"]


### PR DESCRIPTION
<!-- Please link an issue via keyword. If you do not know what this means, please click this link: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword. -->

Fixes #147

<!-- Please note all the changes you've made. A good rule of thumb is to have at least one bullet point per file changed. -->

### Changes
- Added prettier hook to the `.pre-commit-config.yaml` file as recommended by [option 3 from the Prettier documentation](https://prettier.io/docs/en/precommit.html#option-3-pre-commithttpsgithubcompre-commitpre-commit) because I think it best fits our use case of working with a multi-language project
- Chose `v2.7.1` as it seems to be the latest stable version of prettier supported by the [mirrors-prettier repo](https://github.com/pre-commit/mirrors-prettier) that the Prettier docs recommend using
- Added `nodejs` and `npm` to apk dependencies in `linter.dockerfile` because prettier requires them or else `docker compose build linter` will fail


### Testing
-  Rebuild linter image with `docker compose build linter`
- Disable prettier on save if you have that configured and then mess up the spacing on one of the files.
- After adding changes to staging area with `git add .` try running `docker compose run linter` and it should reformat the staged file with output in terminal that looks like this

![image](https://user-images.githubusercontent.com/73561520/235277736-f75f397a-b1e6-4ac8-a9ca-5c2db960604d.png)


<!-- Please ignore everything below until #78 closes. -->

<!-- Please attach full page screenshots of changes to the website's appearance before and after code changes in HTML drop boxes (see below template). DO NOT POST PICTURES OF YOUR CODE! -->

<!-- Commented out
### Screenshots, if applicable

<details>
  <summary>Title</summary>
  <br>
  <img src="" width="600" length="300" />
  <br>
</details>
-->
