### PR TITLE
Bash script for aliases

### DIFF
--- a/alias-config.txt
+++ b/alias-config.txt
@@ -1,0 +1,6 @@
+build: docker compose build
+start:docker compose up
+stop:docker compose down
+build-linter:docker compose build linter
+lint:docker compose run linter
+test:docker compose run webpack npm run test

--- a/alias-config.txt
+++ b/alias-config.txt
@@ -2,5 +2,5 @@ build: docker compose build
 start:docker compose up
 stop:docker compose down
 build-linter:docker compose build linter
-lint:docker compose run linter
-test:docker compose run webpack npm run test
+lint:docker compose up linter
+test:docker compose run -T webpack npm run test

--- a/alias.sh
+++ b/alias.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# Configuration file containing shortened versions and associated commands
+config_file='alias-config.txt'
+
+# Check if the config file exists
+if [ ! -f "$config_file" ]; then
+  echo "Configuration file not found: $config_file"
+  exit 1
+fi
+
+# Function to display help message
+show_help() {
+  echo "Usage: $0 <alias>"
+  echo ""
+  echo "Options:"
+  echo "  -h   Show help message"
+  echo ""
+  echo "Available commands:"
+  while IFS=':' read -r alias command || [ -n "$alias" ]; do
+    printf "  %-8s %s\n" "$alias" "$command"
+  done < "$config_file"
+}
+
+# If no arguments provided or the argument is -h, show help message
+if [ $# -eq 0 ] || [ "$1" = "-h" ]; then
+  show_help
+  exit 0
+fi
+
+# Read the config file to find the matching shortened version
+while IFS=':' read -r alias command; do
+  if [ "$alias" = "$1" ]; then
+    # The -q flag suppresses the output from the script command itself
+    # The -c flag specifies the command to run and /dev/null discards the typescript file that script would normally generate
+    script -q -c "$command" /dev/null
+    exit 0
+  fi
+done < "$config_file"
+
+# If no matching shortened version is found, display an error message
+echo "Unknown alias (shortcut name for command): $1"
+echo "Run $0 -h for more information."
+exit 1

--- a/alias.sh
+++ b/alias.sh
@@ -3,12 +3,6 @@
 # Configuration file containing shortened versions and associated commands
 config_file='alias-config.txt'
 
-# Check if the config file exists
-if [ ! -f "$config_file" ]; then
-  echo "Configuration file not found: $config_file"
-  exit 1
-fi
-
 # Function to display help message
 show_help() {
   echo "Usage: $0 <alias>"
@@ -31,9 +25,7 @@ fi
 # Read the config file to find the matching shortened version
 while IFS=':' read -r alias command; do
   if [ "$alias" = "$1" ]; then
-    # The -q flag suppresses the output from the script command itself
-    # The -c flag specifies the command to run and /dev/null discards the typescript file that script would normally generate
-    script -q -c "$command" /dev/null
+    $command
     exit 0
   fi
 done < "$config_file"

--- a/mkdocs/docs/developer/devops.md
+++ b/mkdocs/docs/developer/devops.md
@@ -36,6 +36,8 @@ _<p style="text-align: center;">Overall project structure</p>_
 │    └── dev.env.example
 ├── .dockerignore
 ├── docker-compose.yml
+├── alias-config.txt
+└── alias.sh
 ```
 
 _<p style="text-align: center;">DevOps Architecture</p>_
@@ -53,6 +55,7 @@ Our devops files can be thought of as a set of files needed to create an exact r
 - **dev/:** contains two dockerfiles and an env file. `django.dockerfile` contains information for our Django server setup. `webpack.dockerfile` contains information to start our webpack watch plugin. `dev.env.example` is an example of the env file needed to configure our dev environment.
 - **.dockerignore:** This file tells Docker to ignore certain files when building the container. These are usually files that pertain to docker or git, which are not important when building the webserver.
 - **docker-compose.yml:** Contains instructions for docker when we run "docker compose". To know more about what each line does, please consult [Docker's documentation](https://docs.docker.com/compose/compose-file/).
+- **alias.sh:** Contains a shell script that allows for cumbersome commands to be executed with less typing by leveraging the aliases listed in `alias-config.txt`
 
 ## Docker
 
@@ -141,6 +144,18 @@ docker compose build --progress=plain
 ```
 
 Sometimes when a build is happening, the logs are too opaque to debug if a step goes wrong. This commands makes the logs a bit more verbose so that you might have an easier time debugging.
+
+### Alias Shell Script
+
+For convenience, we have created a shell script that allows for longer commands to be executed with less typing. The script is capable of executing any of the commands listed in `alias-config.txt` without having to type out the entire command.
+
+### `alias.sh`
+
+To use this script, run `bash alias.sh $arg` or `./alias.sh $arg` where `$arg` is the alias of the command you wish to execute. For example, try running `bash alias.sh test`.
+
+### `alias-config.txt`
+
+This file contains many of the important commands you will need when developing for this project. Note that each command starts with a single word followed by a `:` and then a command. You must follow this pattern when adding additional commands to the file. Please note that any `docker run` commands must use the `-T` flag to allocate a pusedo-TTY or the command will not work.
 
 ## Additional Resources
 

--- a/mkdocs/docs/developer/installation.md
+++ b/mkdocs/docs/developer/installation.md
@@ -95,6 +95,14 @@ In this scenario, the full command would be:
 
 `docker compose run webpack npm install`
 
+##### 5. [webpack-cli] [Error: EACCES: permission denied', open '/code/frontend/templates/frontend/index.html']
+
+In this case, the `index.html` file has incorrect ownership and/or permissions. To fix this, run the following command in the root directory of the CTJ repository:
+
+`sudo chown -R $USER:$USER`
+
+This will utilize superuser permissions to change the user and group ownership of all the files and directories in the current directory to the current user.
+
 ## Additional Resources
 
 [Git Documentation](https://git-scm.com/doc)<br>


### PR DESCRIPTION
<!-- Please link an issue via keyword. If you do not know what this means, please click this link: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword. -->

Fixes #192

<!-- Please note all the changes you've made. A good rule of thumb is to have at least one bullet point per file changed. -->

### Changes

- Added shell script `alias.sh` that leverages the `alias-config.txt` file allowing us to create shortened versions of longer shell commands and run them like `./alias.sh test`
- Populated `alias-config.txt` with as many commands as I could find from our mkdocs

### Considerations 
- You will most likely need to give the script file permission to execute with a command like `chmod u+x alias.sh` if you want to run script with `./alias.sh start` , but you might be okay to use `bash ./alias.sh start` without modifying permissions
- While researching, I was warned that not all operating systems ship with the `script` command installed by default.
     -  The trade off is that if we use `eval "$command"` instead then we will have to add `-T` option to `docker run` commands in the `alias-config.txt` file because they require a `TTY` context by default
     - Also when running `./alias.sh test` the terminal won't show the pretty colors if we decide to use `eval` instead of `script`


<!-- Please ignore everything below until #78 closes. -->

<!-- Please attach full page screenshots of changes to the website's appearance before and after code changes in HTML drop boxes (see below template). DO NOT POST PICTURES OF YOUR CODE! -->

<!-- Commented out
### Screenshots, if applicable

<details>
  <summary>Title</summary>
  <br>
  <img src="" width="600" length="300" />
  <br>
</details>
-->
