### PR TITLE
Fixing local development environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - ./dev/dev.env
     volumes:
       - ./:/code # The webpack output files are now in a sibling directory, therefore, we need to mount to parent
+      - node_modules:/code/node_modules # Need to persist node_modules directory to prevent it from being overwritten by local directory mount (on line 40). This ensures npm packages installed during Docker build are available at runtime.
 
   linter:
     profiles: ["lint"]
@@ -56,3 +57,4 @@ services:
 
 volumes:
   postgres_data:
+  node_modules:


### PR DESCRIPTION
<!-- Please link an issue via keyword. If you do not know what this means, please click this link: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword. -->

Fixes #411 

<!-- Please note all the changes you've made. A good rule of thumb is to have at least one bullet point per file changed. -->

### Changes

- Added a volume within the `webpack` service that points to the newly created named volume `node_modules` that sits at the root level of the `docker-compose.yml` file so that the necessary node packages will now persist inside of the `webpack` container
- The `webpack` container no longer exits with an error


### Requirements
- For the fix to work you will need to run `docker compose build --no-cache` while on my branch. Then run `docker compose up`

### Explanation
[GPT4 conversation](https://chat.openai.com/share/5a6325ba-e50a-4c79-acf4-785590fe7476)

The `webpack` container was exiting with the following error
```
[ CivicTechJobs ] $ docker logs 2d14073c954db70485b03e6f69ca2de7829a0d64994185aad0ead6b66ca902b8
npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path /code/package.json
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, open '/code/package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2023-06-24T22_04_08_651Z-debug-0.log
```

The reason `package.json` did not exist inside of the `webpack` container was because line 39/40 of `docker-compose.yml` 
```
    volumes:
      - ./:/code # The webpack output files are now in a sibling directory, therefore, we need to mount to parent
```
was overwriting the work done by the `build` of the `webpack` service where the `webpack.dockerfile` is executed which is the part that copies `package.json`from our local machine into the docker host and installs all the packages.

The reason we were getting `Template does not exist at /` from django was because the `backend/frontend/templates/frontend/` folder did not contain an `index.html` file. The `index.html` file at that path is supposed to be outputted via line 15 of `webpack.config.js`. However, since the `webpack` container was failing, this event was not being triggered.

Note that all of the files at the paths `backend/frontend/static/frontend` and `backend/frontend/templates/frontend` are purposely ignored by git and while they start out with only a `.gitkeep` file inside, after you `docker compose up` with the fix from this PR they are filled with all the necessary files :champagne: :beers: :tada: 

<!-- Please attach full page screenshots of changes to the website's appearance before and after code changes in HTML drop boxes (see below template). DO NOT POST PICTURES OF YOUR CODE! -->

### Screenshots
Before 
![image](https://github.com/hackforla/CivicTechJobs/assets/73561520/dbfd3eb7-440d-4a6f-bcfd-19c441ef654c)


After
![image](https://github.com/hackforla/CivicTechJobs/assets/73561520/3be2e8c7-a239-4564-805f-990a9966d3d8)

