### PR TITLE
Revert "update pyyaml version"

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.11"
 Django = "^4.2.1"
 djangorestframework = "^3.14.0"
 psycopg2-binary = "^2.9.6"
-pyyaml = "^6.0.1"
+pyyaml = "^6.0"
 uritemplate = "^4.1.1"
 
 [tool.poetry.group.staging]


### PR DESCRIPTION
Reverts #431


The `Build, push image to ECR and deploy to ECS` job is still failing and has an additional error related to the pyyaml version after merging #431 

```
#20 2.767 Because backend depends on pyyaml (^6.0.1) which doesn't match any versions, version solving failed.
```
https://github.com/hackforla/CivicTechJobs/actions/runs/5906751481/job/16023388193#step:5:214