### PR TITLE
Attempt fix for staging deployment

### DIFF
--- a/stage/Dockerfile
+++ b/stage/Dockerfile
@@ -26,7 +26,7 @@ ENV PATH="$POETRY_HOME/bin:${PATH}"
 SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3018
-RUN apk update && apk add --no-cache curl gcc musl-dev libffi-dev jq
+RUN apk update && apk add --no-cache curl gcc musl-dev libffi-dev jq postgresql-dev
 # I could not make the linter accept 4006, so I will put this here. Whoever is interested should find a way to resolve this without ignoring. 
 # hadolint ignore=DL4006
 RUN curl -sSL https://install.python-poetry.org | python3 -


### PR DESCRIPTION
Fixes #457

### Changes
- Added `postgresql-dev` to the dockerfile that build image used for staging site deployment
- I think the root of problem is that `pg_config` cannot be found and GPT thinks that installing `postgresql-dev` as part of the image building process will make `pg_config` available


![image](https://github.com/hackforla/CivicTechJobs/assets/73561520/9564aeda-de5d-49e8-b500-63f21fc7f831)


