### PR TITLE
Rollback markdown to v3.2.0

### DIFF
--- a/.github/workflows/mkdocs-build.yml
+++ b/.github/workflows/mkdocs-build.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Publish docs
         run: |
           pip install --upgrade pip && pip install setuptools mkdocs
+          pip install markdown==3.2.0
           python mkdocs/mkdocs-config/setup.py develop
           git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
           cd mkdocs


### PR DESCRIPTION
Fixes https://github.com/hackforla/CivicTechJobs/issues/456

Changes

- Uses Markdown 3.2.0.