### PR TITLE
Add healthcheck api for new backend

### DIFF
--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -111,6 +111,8 @@ USE_I18N = True
 
 USE_TZ = True
 
+VERSION = '1.0.0'
+
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.0/howto/static-files/

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -15,8 +15,10 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path("ctjbackend/", include("ctjbackend.urls")),
 ]

--- a/backend/ctjbackend/apps.py
+++ b/backend/ctjbackend/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+import ctjbackend.uptime
 
 
 class CtjbackendConfig(AppConfig):

--- a/backend/ctjbackend/uptime.py
+++ b/backend/ctjbackend/uptime.py
@@ -1,0 +1,3 @@
+import datetime
+
+start_time = datetime.datetime.now()

--- a/backend/ctjbackend/urls.py
+++ b/backend/ctjbackend/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from ctjbackend import views
+
+urlpatterns = [
+  path('healthcheck/', views.healthcheck, name='healthcheck'),
+]

--- a/backend/ctjbackend/views.py
+++ b/backend/ctjbackend/views.py
@@ -1,3 +1,26 @@
 from django.shortcuts import render
+from django.http import JsonResponse
+from django.conf import settings
+import datetime
+from ctjbackend.uptime import start_time
 
-# Create your views here.
+
+# Healthcheck view that returns the uptime of the app, a healthcheck message, and the version.
+def healthcheck(request):
+  current_time = datetime.datetime.now()
+  uptime_duration = current_time - start_time
+  uptime_seconds = int(uptime_duration.total_seconds())
+
+  hours = int(uptime_seconds // 3600)
+  minutes = int((uptime_seconds % 3600) // 60)
+  seconds = int(uptime_seconds % 60)
+
+  uptime_str = f"{hours:02d} hours {minutes:02d} minutes {seconds:02d} seconds"
+
+  context = {
+      "message": "healthcheck",
+      "uptime": uptime_str,
+      "version": settings.VERSION,
+  }
+  
+  return JsonResponse(context)


### PR DESCRIPTION
<!-- Please link an issue via keyword. If you do not know what this means, please click this link: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword. -->

Fixes #523

<!-- Please note all the changes you've made. A good rule of thumb is to have at least one bullet point per file changed. -->

### Changes

- Configured api urlpatterns to include ctjbackend.
- Created Healthcheck View that returns JSON that includes application uptime, a healthcheck message, and version.
- Created healthcheck path in ctjbackend urlpatterns
