### PR TITLE
update readme.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/post-an-open-role.md
+++ b/.github/ISSUE_TEMPLATE/post-an-open-role.md
@@ -1,0 +1,13 @@
+---
+name: Post an open role
+about: Recruit volunteers for specific open roles template
+title: 'CTJ: Open Role for: [Replace with NAME OF ROLE]'
+labels: 'Complexity: Small, feature: recruiting, role missing'
+assignees: ''
+
+---
+
+<img src="https://user-images.githubusercontent.com/37763229/216711442-d23388f1-3195-4420-b342-2b3ad4ff041f.png">
+
+[INSERT DRAFT FROM THE Recruit volunteers for team open roles issue]
+

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Civic Tech technology practitioners are a diverse and interdisciplinary group of
 
 ### Collaboration Technologies
 
-- [GitHub Project Board](https://github.com/hackforla/CivicTechJobs/projects/1)
+- [GitHub Project Board](https://github.com/orgs/hackforla/projects/37)
 - [Slack](https://hackforla.slack.com/archives/C02509WHFQQ)
-- [Google Drive](https://drive.google.com/drive/u/0/folders/0AMdnUkSXicNCUk9PVA)
+- [Google Drive](https://drive.google.com/drive/u/0/folders/1hXxvpC8W5Uuzjqo4CxnjDpAMI7sbVnq8)
 - [Figma](https://www.figma.com/file/G5bOqhud6azbxyR9El9Ygp/Civic-Tech-Jobs?node-id=0%3A1)
 
 ### Project Tech Stack

--- a/mkdocs/docs/joining-the-team/intro.md
+++ b/mkdocs/docs/joining-the-team/intro.md
@@ -10,12 +10,13 @@ Welcome to the Civic Tech Jobs team! This guide will help get you up to speed on
 
 If you have not read the [Guide for New Volunteers](https://www.hackforla.org/getting-started), please do so.
 
-1. Read [Introduction to the Project](https://hackforla.github.io/CivicTechJobs/) if you haven't already read it.
-1. Join the [Civic Tech Jobs](https://hackforla.slack.com/archives/C02509WHFQQ) Slack channel and introduce yourself and mention the role you are interested in. Our PM's [Joyce Guo](https://hackforla.slack.com/team/U05JUKMMVDJ) & [Sabrina Heasley](https://hackforla.slack.com/team/U05GDBDPEDR) will help you get onboarded with the following steps.
-1. Complete this form [Team Roster Onboarding Form](https://docs.google.com/forms/d/e/1FAIpQLSfv-VTLseKixhzbPvY_hBHW30CaokUh4FOmst-4ZEM639EinQ/viewform) and inform PM after you have done so.
+1. Check the [Community of Practice -> Open Roles Board](https://github.com/hackforla/communities-of-practice) for current open roles in the Civic Tech Jobs project.
+2. Read [Introduction to the Project](https://hackforla.github.io/CivicTechJobs/) if you haven't already read it.
+3. If interested in joining the team, complete this form [Team Roster Onboarding Form](https://docs.google.com/forms/d/e/1FAIpQLSfv-VTLseKixhzbPvY_hBHW30CaokUh4FOmst-4ZEM639EinQ/viewform).
+4. Join the [Civic Tech Jobs](https://hackforla.slack.com/archives/C02509WHFQQ) Slack channel and introduce yourself and mention the role you are interested in. Our PM's will help you get onboarded with the following steps.
 1. Accept your Google Drive invite to access the [shared folder](https://drive.google.com/drive/u/0/folders/0AMdnUkSXicNCUk9PVA).
 1. Review the [Glossary](https://hackforla.github.io/CivicTechJobs/misc/glossary/).
-1. Attend our weekly meetings on Tuesdays at 5pm PST. You can find the link pinned in our slack channel.
+1. Attend our monthly all team meeting on the third Tuesday at 5pm PST. You can find the link pinned in our slack channel.
 
 ---
 

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -18,12 +18,6 @@ nav:
       - Web Developer: joining-the-team/web-developer.md
       - Other Volunteer: joining-the-team/other-volunteer.md
   - Docs:
-      #- Product Manager:
-      #  - Placeholder: about.md
-      #- UI Designer:
-      #  - Placeholder: about.md
-      #- UX Researcher:
-      #  - Placeholder: about.md
       - Web Developer:
           - CONTRIBUTING.md: https://github.com/hackforla/CivicTechJobs/blob/main/CONTRIBUTING.md#welcome-to-the-civictechjobs-contributing-guide
           - Backend Architecture: developer/backend.md
@@ -36,7 +30,7 @@ nav:
       - Misc:
           - ADA Guide: misc/ada-guide.md
           - Glossary: misc/glossary.md
-          - History: misc/history.md
+          - History: https://github.com/hackforla/CivicTechJobs/wiki/History#history
           - Our Process: misc/our-process.md
           - Research Wiki Template: misc/research-wiki-template.md
           - Security Updates: misc/security-updates.md


### PR DESCRIPTION
Fix broken links in README.md and MkDocs configuration (#561)

### Changes
- Updated README.md:
  - Fixed broken project board link
  - Corrected Google Drive link with proper permissions
- Modified mkdocs.yml:
  - Added 'History' entry under the 'Misc' section
  - Set 'History' link to point directly to the GitHub wiki page

