### PR TITLE
Added pgdb healthcheck to the docker-compose.dev.yml

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -42,7 +42,7 @@ services:
   vite:
     build:
       context: frontend
-      dockerfile: ../dev/vite.dockerfile
+      dockerfile: ../dev/vite.Dockerfile
     container_name: vite
     env_file:
       - dev/dev.env

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ name: CivicTechJobs
 
 services:
   pgdb:
-    image: postgres:12
+    image: postgres:16
     container_name: pgdb
     volumes:
       - postgres_data:/lib/postgresql/data
@@ -10,6 +10,11 @@ services:
       - dev/dev.env
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   
   django:
     build:
@@ -24,9 +29,10 @@ services:
     ports:
       - "8000:8000"
     env_file:
-    - dev/dev.env
+      - dev/dev.env
     depends_on:
-      - pgdb
+      pgdb:
+        condition: service_healthy
     develop:
       watch:
         - action: sync


### PR DESCRIPTION
Fixes #
Issue:
In the `docker-compose.dev.yml`, there was no healthcheck for the postgres db container to make sure it's working before starting the django container.
- Jimmy quote from 09/05/24 meeting: "django needs a restart clause to make sure postgres container is ready"
- [depends\_on doesn't wait for another service in docker-compose 1.22.0 - Stack Overflow](https://stackoverflow.com/questions/52699899/depends-on-doesnt-wait-for-another-service-in-docker-compose-1-22-0)
- Used this link to help create the docker-compose file: [Dockerizing Django with Postgres, Gunicorn, and Nginx | TestDriven.io](https://testdriven.io/blog/dockerizing-django-with-postgres-gunicorn-and-nginx/)

This PR should fix it.

How to test:
Start the application in dev mode from my `feat/vite-hmr` branch:
```sh
docker compose -f docker-compose.dev.yml up --watch
```

Test client with this URL:
```
http://localhost:8000
```

Test server with this URL:
```
http://localhost:8000/api/opportunities/
```

<!-- Please note all the changes you've made. A good rule of thumb is to have at least one bullet point per file changed. -->

### Changes

- Added a healthcheck to postgres container
- Added the pgdb healthcheck as a dependency to start the django container
- capitalized `vite.Dockerfile` to fix a typo in the file name

### Screenshots, if applicable
None
