### PR TITLE
Feature: Add healthcheck api endpoint for new backend

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -13,6 +13,8 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 from pathlib import Path
 from decouple import config
 
+VERSION = '1.0.0'
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -26,8 +28,7 @@ SECRET_KEY = config('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = config('DEBUG', default=False, cast=bool)
 
-ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1"]
-
+ALLOWED_HOSTS = config("DJANGO_ALLOWED_HOSTS", default="localhost").split(" ")
 
 # Application definition
 

--- a/backend/ctj_api/urls.py
+++ b/backend/ctj_api/urls.py
@@ -4,5 +4,6 @@ from ctj_api import views
 
 urlpatterns = [
     path('opportunities/', views.OpportunitiesList.as_view()),
-    path('opportunities/<uuid:pk>/', views.OpportunitiesDetails.as_view())
+    path('opportunities/<uuid:pk>/', views.OpportunitiesDetails.as_view()),
+    path('healthcheck', views.Healthcheck.as_view(), name='healthcheck')
 ]

--- a/backend/ctj_api/views.py
+++ b/backend/ctj_api/views.py
@@ -1,7 +1,10 @@
 from rest_framework import generics
+from rest_framework.response import Response
+from rest_framework.views import APIView
 from ctj_api.models import Opportunities
 from ctj_api.serializers import OpportunitiesSerializer
-
+from django.conf import settings
+import time
 
 class OpportunitiesList(generics.ListCreateAPIView):
     queryset = Opportunities.objects.all()
@@ -11,3 +14,19 @@ class OpportunitiesList(generics.ListCreateAPIView):
 class OpportunitiesDetails(generics.RetrieveUpdateDestroyAPIView):
     queryset = Opportunities.objects.all()
     serializer_class = OpportunitiesSerializer
+
+class Healthcheck(APIView):
+    start_time = time.time()
+
+    def get(self, request):
+        uptime_seconds = time.time() - self.start_time
+        uptime_hours = uptime_seconds / 3600
+        hostname = request.get_host()
+
+        return Response({
+            "message": "healthcheck",
+            "uptime": f"{uptime_hours:.2f} hours",
+            # "uptime": f"{uptime_seconds:.1f} seconds",
+            "version": settings.VERSION,
+            "hostname": hostname
+        })


### PR DESCRIPTION
Fixes #523 
Just want to quickly resolve and close this issue already.

You can test by going to `http://localhost:8000/api/healthcheck`

### Changes

- Basically copied the code from Bitian's PR here: https://github.com/hackforla/CivicTechJobs/pull/547
- and added a property for `hostname` in the json response

Looks like Bitian's code was accidentally removed when Jimmy was initializing a new backend in this commit: https://github.com/hackforla/CivicTechJobs/commit/b28bdba05ed0f9121e9dbdce64e621ef00c1506e

### Screenshots, if applicable
![image](https://github.com/user-attachments/assets/9be98194-838a-4054-b16a-3238bfd7718a)

