### PR TITLE
Added linter to docker compose dev file

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -53,6 +53,20 @@ services:
         - action: sync
           path: ./frontend
           target: /usr/src/app
+  linter:
+    profiles: ["lint"]
+    build:  
+      context: .
+      dockerfile: ./dev/linter.dockerfile
+    container_name: linter
+    environment:
+      - PRE_COMMIT_HOME=${HOME}/.cache/pre-commit
+    user: ${UID}:${GID}
+    env_file:
+      - ./dev/linter.env
+    volumes:
+      - .:/src:rw
+      - ${HOME}/.cache:${HOME}/.cache:rw
 
 volumes:
   postgres_data: {}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -57,7 +57,7 @@ services:
     profiles: ["lint"]
     build:  
       context: .
-      dockerfile: ./dev/linter.dockerfile
+      dockerfile:  ./dev/linter.dockerfile 
     container_name: linter
     environment:
       - PRE_COMMIT_HOME=${HOME}/.cache/pre-commit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,17 @@ services:
     volumes:
       - ./data/db:/var/lib/postgresql/data
     environment:
-      - POSTGRES_USER=yourusername  # Set the username for the PostgreSQL database
-      - POSTGRES_PASSWORD=yourpassword  # Set the password for the PostgreSQL database
-      - POSTGRES_DB=yourdatabase  # Set the name of the database
+      - POSTGRES_USER=ctj-user  # Set the username for the PostgreSQL database
+      - POSTGRES_PASSWORD=ctj-db  # Set the password for the PostgreSQL database
+      - POSTGRES_DB=ctj          # Set the name of the database
     ports:
       - "5432:5432"  # Map the PostgreSQL port to the host
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U yourusername -d yourdatabase"]
+      test: ["CMD-SHELL", "pg_isready -U ctj-user -d ctj"]  # Updated to use the correct user and database
       interval: 10s
       timeout: 5s
       retries: 5
+
   backend:
     build: ./backend
     command: python manage.py runserver 0.0.0.0:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./data/db:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=ctj-user  # Set the username for the PostgreSQL database
-      - POSTGRES_PASSWORD=ctj-db  # Set the password for the PostgreSQL database
+      - POSTGRES_PASSWORD=ctj-db # Set the password for the PostgreSQL database
       - POSTGRES_DB=ctj          # Set the name of the database
     ports:
       - "5432:5432"  # Map the PostgreSQL port to the host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,18 @@
-version: "3.9"  # Use the version of Docker Compose that you need
+version: "3.9" # Use the version of Docker Compose that you need
 
 services:
   db:
-    image: postgres:16  # Use the latest PostgreSQL image
+    image: postgres:16 # Use the latest PostgreSQL image
     volumes:
       - ./data/db:/var/lib/postgresql/data
     environment:
-      - POSTGRES_USER=ctj-user  # Set the username for the PostgreSQL database
-      - POSTGRES_PASSWORD=ctj-db # Set the password for the PostgreSQL database
-      - POSTGRES_DB=ctj          # Set the name of the database
+      - POSTGRES_USER=yourusername # Set the username for the PostgreSQL database
+      - POSTGRES_PASSWORD=yourpassword # Set the password for the PostgreSQL database
+      - POSTGRES_DB=yourdatabase # Set the name of the database
     ports:
-      - "5432:5432"  # Map the PostgreSQL port to the host
+      - "5432:5432" # Map the PostgreSQL port to the host
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ctj-user -d ctj"]  # Updated to use the correct user and database
+      test: ["CMD-SHELL", "pg_isready -U yourusername -d yourdatabase"] # Updated to use the correct user and database
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Related to #407 
Just pushing to show what I did to resolve the issue that showed when I ran the `docker compose build linter ` command on my develop branch while onboarding. It told me that it couldn't find the linter service so I added this:
```
 linter:
    profiles: ["lint"]
    build:  
      context: .
      dockerfile: ./dev/linter.dockerfile
    container_name: linter
    environment:
      - PRE_COMMIT_HOME=${HOME}/.cache/pre-commit
    user: ${UID}:${GID}
    env_file:
      - ./dev/linter.env
    volumes:
      - .:/src:rw
      - ${HOME}/.cache:${HOME}/.cache:rw
```
to the` docker-compose.dev.yml ` file under services. Is that the correct place to add the linter service? 
