### PR TITLE
Hotfix/poetry no root

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "../README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"


### PR DESCRIPTION
Fixes #

Poetry broke. Message:
```
The current project could not be installed: No file/folder found for package backend
If you do not want to install the current project use --no-root
```

### Changes

- added `package-mode = false` to pyproject.toml
