### PR TITLE
Update Opportunity Permisson

### DIFF
--- a/backend/ctj_api/permissions.py
+++ b/backend/ctj_api/permissions.py
@@ -7,17 +7,42 @@ class OpportunityPermission(permissions.BasePermission):
     Only the creator of an opportunity can edit it.
     """
 
+    def has_permission(self, request, view):
+        """
+        Check global permissions for the request method.
+        """
+        # Allow safe methods for all users
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        # Only PM's can create opportunities
+        if request.method == "POST":
+            return getattr(request.user, "isProjectManager", False)
+
+        # For PUT and DELETE, defer to object-level permissions
+        if request.method in ["PUT", "DELETE"]:
+            return request.user.is_authenticated
+
+        return False
+
     def has_object_permission(self, request, view, obj):
+        """
+        Check object-level permissions for the request method.
+        """
         # Read permissions are allowed to any request,
         # so we'll always allow GET, HEAD or OPTIONS requests.
         if request.method in permissions.SAFE_METHODS:
             return True
 
-        if request.method == "POST":
-            return request.user.isProjectManager
-
         # PUT permissions are only allowed to the PM that created the opportunity.
-        return obj.created_by == request.user
+        if request.method == "PUT":
+            return obj.created_by == request.user
+
+        # Any PM can delete any opportunity
+        if request.method == "DELETE":
+            return getattr(request.user, "isProjectManager", False)
+
+        return False
 
 
 class UserDetailPermission(permissions.BasePermission):


### PR DESCRIPTION
`test_create_opportunity_as_regular_user` returned 201 instead of 403, so I tried updating the OpportunityPermission to enforce stricter rules for POST, PUT, and DELETE.

<!-- Please note all the changes you've made. A good rule of thumb is to have at least one bullet point per file changed. -->

### Changes

- permissions.py
