### PR TITLE
Deploy-stage: rename github action and exclude paths

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "mkdocs/**"
+      - "dev/**"
   workflow_dispatch:
 jobs:
   deploy:


### PR DESCRIPTION
Fixes #

### Changes

- renamed `deploy-dev.yml` github action file to `deploy-stage.yml`
- excluded mkdocs and dev folder paths so the action does not run on changes to files in those folders.
